### PR TITLE
scale_name argument of ggplot2::discrete_scale is deprecated

### DIFF
--- a/R/scale_colour_discrete_af.R
+++ b/R/scale_colour_discrete_af.R
@@ -30,7 +30,6 @@ scale_colour_discrete_af <- function(palette = "main",
   palette_type <- match.arg(palette_type)
 
   ggplot2::discrete_scale("colour",
-    paste0(palette_type, "_", palette),
     palette = af_palette(palette, reverse, palette_type = palette_type),
     ...
   )

--- a/R/scale_fill_discrete_af.R
+++ b/R/scale_fill_discrete_af.R
@@ -29,7 +29,6 @@ scale_fill_discrete_af <- function(palette = "main",
   palette_type <- match.arg(palette_type)
 
   ggplot2::discrete_scale("fill",
-    paste0(palette_type, "_", palette),
     palette = af_palette(palette, reverse, palette_type = palette_type),
     ...
   )


### PR DESCRIPTION
@fingertipsy could you please review? Warnings were being generated when running tests as the scale_name  argument of ggplot2::discrete_scale is deprecated